### PR TITLE
solves #15

### DIFF
--- a/GVFlib/GVF.cpp
+++ b/GVFlib/GVF.cpp
@@ -17,7 +17,8 @@
 #include <fstream>
 #include <sstream>
 #include <memory>
-#include <unistd.h>
+#include <algorithm>
+#include <numeric>
 
 //debug max
 //#include "ext.h"


### PR DESCRIPTION
Replaced `unistd.h` with necessary std libraries for the methods used in the class.
Tested on Visual Studio 2015, Windows 8.1 and OSX 10.10.5, XCode 7.2.1.